### PR TITLE
ci: harden supply chain via dependabot cooldown and pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      ci:
+        patterns:
+          - "*"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    groups:
+      dev:
+        dependency-type: "development"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -31,19 +31,19 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
@@ -59,12 +59,12 @@ jobs:
       id-token: write # required for Trusted Publishing to PyPI
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: cibw-*
           path: wheelhouse
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: wheelhouse

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -22,13 +22,13 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: release-please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: .github/release-please-config.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Hardens the repository against supply chain attacks by tightening Dependabot configuration and pinning all third-party GitHub Actions to immutable commit SHAs.

## Dependabot

- Adds a 7-day **cooldown** for both `github-actions` and `uv` ecosystems, so newly published versions are not auto-proposed immediately.
- Groups `github-actions` updates into a single `ci` group.
- Groups `uv` development dependencies into a `dev` group (no production deps in this repo today).

Inspired by [equinor/rock-physics-open's dependabot.yaml](https://github.com/equinor/rock-physics-open/blob/main/.github/dependabot.yaml).

## Pinned GitHub Actions

All third-party actions are now pinned to a commit SHA with the exact tag as an inline comment. Versions chosen are the latest released at least 7 days ago (matching the dependabot cooldown).

| Action | Version |
|---|---|
| `actions/checkout` | v6.0.2 |
| `actions/setup-python` | v6.2.0 |
| `actions/upload-artifact` | v7.0.1 |
| `actions/download-artifact` | v8.0.1 |
| `actions/create-github-app-token` | v3.2.0 |
| `googleapis/release-please-action` | v5.0.0 |
| `pypa/cibuildwheel` | v3.4.1 |
| `pypa/gh-action-pypi-publish` | v1.14.0 (was floating `release/v1` branch) |
| `astral-sh/setup-uv` | v8.1.0 (bumped from v7; upstream dropped major/minor tags) |

## `--locked` installs

Verified: all `uv sync` invocations in workflows already use `--locked --all-groups`. No changes needed.